### PR TITLE
Removing Chain-ID

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -12,7 +12,6 @@ edge_user: edge
 is_validator: false
 
 loadtest_account: "0x85da99c8a7c2c95964c8efd687e95e632fc533d6"
-rootchain_json_rpc: http://geth-001:8545
 
 edge_grpc_port: 10000
 edge_p2p_port: 10001

--- a/ansible/local-extra-vars.yml
+++ b/ansible/local-extra-vars.yml
@@ -3,12 +3,37 @@ clean_deploy_title: devnet13
 
 block_gas_limit: 50_000_000
 block_time: 5
-chain_id: 2001
 
-polycli_tag: 0.1.20
+polycli_tag: 0.1.22
 edge_tag: v0.9.0
 geth_tag: v1.11.6
-go_tag: 1.19.7.linux-amd64
+go_tag: 1.19.9.linux-amd64
+
+# this is the amount of value that will be transfered on the rootchain to the deployer address and the validators
+# rootchain_validator_fund_amount: 100ether
+# rootchain_deployer_fund_amount: 10000000ether
+rootchain_deployer_fund_amount: 10ether
+rootchain_validator_fund_amount: 1ether
+
+
+
+# this is the rpc url that will be used for the root chain
+# rootchain_json_rpc: http://geth-001:8545
+rootchain_json_rpc: https://matic-mumbai.chainstacklabs.com
+
+# When our l1 is geth with an unlocked account, we'll need to send
+# ether from the randomly created coinbase to our predetermined
+# account. Set this to true in order to fund. Set this to false if the
+# coinbase account is already funded
+
+# fund_rootchain_coinbase: true
+fund_rootchain_coinbase: false
+
+# This account is just for testing purposes. Don't actually use it. If
+# the L1 is NOT an unlocked test account, then you'll need some wallet
+# for funding validators. The address and private key here are used for this purpose
+rootchain_coinbase_address: "0xC7FDEe289150041f2c4AAEF095e8a6715223663C"
+rootchain_coinbase_private_key: "0xc0ffec0ffec0ffec0ffec0ffec0ffec0ffec0ffec0ffec0ffec0ffec0ffeDEAD"
 
 ansible_ssh_private_key_file: ~/devnet_private.key
 ansible_ssh_common_args: >

--- a/ansible/local-extra-vars.yml
+++ b/ansible/local-extra-vars.yml
@@ -10,24 +10,23 @@ geth_tag: v1.11.6
 go_tag: 1.19.9.linux-amd64
 
 # this is the amount of value that will be transfered on the rootchain to the deployer address and the validators
-# rootchain_validator_fund_amount: 100ether
-# rootchain_deployer_fund_amount: 10000000ether
-rootchain_deployer_fund_amount: 10ether
-rootchain_validator_fund_amount: 1ether
+rootchain_validator_fund_amount: 100ether
+rootchain_deployer_fund_amount: 10000000ether
+# rootchain_deployer_fund_amount: 10ether
+# rootchain_validator_fund_amount: 1ether
 
 
 
 # this is the rpc url that will be used for the root chain
-# rootchain_json_rpc: http://geth-001:8545
-rootchain_json_rpc: https://matic-mumbai.chainstacklabs.com
+rootchain_json_rpc: http://geth-001:8545
+# rootchain_json_rpc: https://matic-mumbai.chainstacklabs.com
 
 # When our l1 is geth with an unlocked account, we'll need to send
 # ether from the randomly created coinbase to our predetermined
 # account. Set this to true in order to fund. Set this to false if the
 # coinbase account is already funded
-
-# fund_rootchain_coinbase: true
-fund_rootchain_coinbase: false
+fund_rootchain_coinbase: true
+# fund_rootchain_coinbase: false
 
 # This account is just for testing purposes. Don't actually use it. If
 # the L1 is NOT an unlocked test account, then you'll need some wallet


### PR DESCRIPTION
A few tactical fixes:
- removing `--chain-id` from genesis and reading it from L1 Contract
- Moving `rootchain_json_rpc` to local variables file
- Adding commented code that could be used to deploy to Mumbai rather than an unlocked L1 test account