### PR TITLE
Remove stake-manager from supernet command

### DIFF
--- a/ansible/roles/edge/templates/bootstrap.sh
+++ b/ansible/roles/edge/templates/bootstrap.sh
@@ -144,7 +144,6 @@ main() {
     polygon-edge polybft supernet \
                  --private-key $(cat rootchain-wallet.json | jq -r '.HexPrivateKey') \
                  --supernet-manager $(cat genesis.json | jq -r '.params.engine.polybft.bridge.customSupernetManagerAddr') \
-                 --stake-manager $(cat genesis.json | jq -r '.params.engine.polybft.bridge.stakeManagerAddr') \
                  --finalize-genesis-set \
                  --enable-staking \
                  --jsonrpc {{ rootchain_json_rpc }}


### PR DESCRIPTION
We have figured out that we do not need `stake-manager` address provided to the `supernet` command. Therefore that flag is removed and bootstrap script updated accordingly.

This is dependant upon https://github.com/0xPolygon/polygon-edge/pull/2002, so it should be merged only after it gets merged.